### PR TITLE
#EP-1962 `cloneDeep` a message if it can’t be serialized

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,23 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+        cache: 'yarn'
+    - run: yarn
+    - run: yarn run build
+    - run: yarn test

--- a/integration.karma.conf.js
+++ b/integration.karma.conf.js
@@ -11,7 +11,7 @@ const options = require('./make-karma-config')({
     dir: 'coverage/integration'
   },
   useIframe: false,
-  browsers: [process.env.TRAVIS ? 'chrome_travis_ci' : 'ChromeHeadless', 'Firefox'],
+  browsers: [process.env.TRAVIS ? 'chrome_travis_ci' : 'ChromeHeadless', 'FirefoxHeadless'],
   concurrency: 1
 })
 

--- a/src/pm-rpc/privates/__tests__/messageManagerSpec.js
+++ b/src/pm-rpc/privates/__tests__/messageManagerSpec.js
@@ -1,0 +1,38 @@
+import _ from 'lodash'
+import {send} from '../messageManager'
+
+function createTarget() {
+  const {port1, port2} = new MessageChannel()
+  port1.onmessage = _.noop
+  spyOn(port2, 'postMessage').and.callThrough()
+  return port2
+}
+
+async function sendWithResolve(message, ...rest) {
+  // `send` sets `.__port` property
+  const sendPromise = send(message, ...rest)
+
+  message.__port.postMessage({intent: 'resolve', result: 'b206275b931a'})
+
+  return sendPromise
+}
+
+describe('messageManager', () => {
+  describe('send', () => {
+    it('should call `target.postMessage`', async () => {
+      const target = createTarget()
+      const message = {a: 'e45cc3a216d8'}
+      await sendWithResolve(message, {target})
+
+      expect(target.postMessage).toHaveBeenCalledWith(message, [jasmine.any(MessagePort)])
+    })
+
+    it('should not fail `target.postMessage` for messages with Proxy', async () => {
+      const target = createTarget()
+      const message = {a: '34de4cb70fd9', c: new Proxy({d: 0}, {get: _.constant(1)})}
+      await sendWithResolve(message, {target})
+
+      expect(target.postMessage).toHaveBeenCalledWith(message, [jasmine.any(MessagePort)])
+    })
+  })
+})

--- a/src/pm-rpc/privates/__tests__/messageManagerSpec.js
+++ b/src/pm-rpc/privates/__tests__/messageManagerSpec.js
@@ -14,7 +14,13 @@ async function sendWithResolve(message, ...rest) {
 
   message.__port.postMessage({intent: 'resolve', result: 'b206275b931a'})
 
-  return sendPromise
+  // i could't get `send` to resolve even with `message.__port.postMessage`, so i'm doing `setTimeout` instead
+  // (errors thrown by `send` still bubble up to here)
+  // https://github.com/wix/pm-rpc/pull/25#discussion_r663927282
+  return Promise.race([
+    sendPromise,
+    new Promise(r => setTimeout(r, 100))
+  ])
 }
 
 describe('messageManager', () => {

--- a/src/pm-rpc/privates/messageManager.js
+++ b/src/pm-rpc/privates/messageManager.js
@@ -1,14 +1,43 @@
 import {isWorker} from './windowModule'
+import cloneDeep from 'lodash/cloneDeep'
+
+function postMessage(target, message, targetOrigin, transfer) {
+  if (isWorker() || target instanceof Worker || target instanceof MessagePort) {
+    target.postMessage(message, transfer)
+  } else {
+    target.postMessage(message, targetOrigin, transfer)
+  }
+}
 
 export const send = (message, {target, targetOrigin}, transfer = []) => new Promise(resolve => {
   const {port1, port2} = new MessageChannel()
-  message.__port = port2
-  if (isWorker() || target instanceof Worker || target instanceof MessagePort) {
-    target.postMessage(message, [port2, ...transfer])
-  } else {
-    target.postMessage(message, targetOrigin, [port2, ...transfer])
-  }
   port1.onmessage = ({data}) => resolve(data)
+  message.__port = port2
+  try {
+    postMessage(target, message, targetOrigin, [port2, ...transfer])
+  } catch (e) {
+    /*
+      There's (as of July 2021) no "nice" API to check whether value can be passed through `MessagePort`,
+      (i.e. can be "structure cloned"), so we do it by `try/catch`ing the failed `postMessage` calls
+
+      > Why do we need to check it in a first place?
+
+      Because something might try to propagate an event with a `Proxy` object in its payload,
+      and those can't be `postMessage`d and can't be reliably detected (there's no (recurvise) `Proxy.isProxy`)
+
+      see also:
+      - https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+      - https://dassur.ma/things/deep-copy/
+      - https://wix.slack.com/archives/CQGJP31CM/p1623225837185800
+    */
+
+    if (e && e.name === 'DataCloneError') {
+      const clonedMessage = cloneDeep(message)
+      postMessage(target, clonedMessage, targetOrigin, [port2, ...transfer])
+    } else {
+      throw e
+    }
+  }
 })
 
 export const sendResponse = (port, intent) => result => port.postMessage({intent, result})


### PR DESCRIPTION
e.g. if message contains a `Proxy`

See also:
- https://jira.wixpress.com/browse/EP-1962
- https://github.com/wix-private/js-platform-editor-sdk/pull/1154