### PR TITLE
fixed not used target in web workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0]
+
+### Breaking changes:
+
+- fixed not used target in web workers: 
+  ```javascript
+  pmrpc.api.request('appId', {target: customTarget})
+  ```
+  Previously it ignored target in WebWorker and target was always`self`. 
+  After this fix target will be honoured for messages
+
+## [2.0.2]
+
+Not published 
+
+## [2.0.0, 2.0.1]
+
+- Update webpack
+- Change global object for module definition
+- Decrease bundle size 
+
+

--- a/src/pm-rpc/rpc.js
+++ b/src/pm-rpc/rpc.js
@@ -9,10 +9,8 @@ import {serialize as serializeError} from './privates/errorSerializer'
 
 const getTargetInfoFromDef = ({target, initiator}) => {
   switch (true) {
-    case isWorker():
-      return {target: self, targetOrigin: '*'}
-    case typeof parent !== 'undefined' && target === parent:
-      return {target: parent, targetOrigin: '*'}
+    case target instanceof MessagePort:
+      return {target}
     case target instanceof Worker:
       return {target}
     case Boolean(target):
@@ -20,6 +18,10 @@ const getTargetInfoFromDef = ({target, initiator}) => {
         return {target: target.contentWindow, targetOrigin: target.src}
       }
       return {target, targetOrigin: '*'}
+    case isWorker():
+      return {target: self, targetOrigin: '*'}
+    case typeof parent !== 'undefined' && target === parent:
+      return {target: parent, targetOrigin: '*'}
     case Boolean(initiator):
       const element = getChildFrameById(initiator)
       return {target: element.contentWindow, targetOrigin: element.src}


### PR DESCRIPTION
```javascript 
pmrpc.api.request('appId', {target: customTarget})
``` 
Previously it ignored target in WebWorker and target was always`self`. After this fix target will be honoured for messages