### PR TITLE
fix endless pending promise from rpc.api.request() in case when rpc.api.set() was never called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2]
+
+- Fix endless pending promise from `pmrpc.api.request()` method in case when `pmrpc.api.set()` was never called
+
 ## [3.0.1]
 
 - Fix `ReferenceError` in Safari inside workers. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-rpc",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/wix/pm-rpc.git"

--- a/src/pm-rpc/__tests__/rpcSpec.js
+++ b/src/pm-rpc/__tests__/rpcSpec.js
@@ -304,6 +304,13 @@ describe('rpc', () => {
         expect(() => rpc.request(fakeId)).toThrowError('Invalid target')
       })
     })
+
+    it('should make sure that single handler is added when requesting API', () => {
+      spyOn(windowModule, 'isWorker').and.returnValue(true)
+      spyOn(messageHandler, 'addSingleHandler')
+      rpc.request(fakeId)
+      expect(messageHandler.addSingleHandler).toHaveBeenCalledWith(jasmine.any(Function))
+    })
   })
 
   describe('unset API', () => {

--- a/src/pm-rpc/privates/messageHandler.js
+++ b/src/pm-rpc/privates/messageHandler.js
@@ -2,6 +2,7 @@ let isListening = false
 export const addSingleHandler = (handler, workers) => {
   if (!isListening) {
     isListening = true
+    // todo: consider having this subscription long-living (now we subscribe on the first `set`/`request` and unsubscribe on the last `unset`
     self.addEventListener('message', handler)
   }
 

--- a/src/pm-rpc/rpc.js
+++ b/src/pm-rpc/rpc.js
@@ -67,6 +67,8 @@ export const set = (appId, app, {onApiCall, workers} = {}, workersDeprecated) =>
 }
 
 export const request = (appId, targetDef = {}) => {
+  messageHandler.addSingleHandler(onMessage)
+
   const targetInfo = getTargetInfoFromDef(targetDef)
   return send({intent: Intents.REQUEST_API, appId}, targetInfo)
     .then(description => description ?


### PR DESCRIPTION
When a user calls `set()` [method](https://github.com/wix/pm-rpc/blob/master/src/pm-rpc/rpc.js#L66) of `pm-rpc`, it adds a [message handler](https://github.com/wix/pm-rpc/blob/b2396d86ccbd208a7821505bebe377b2de26fc56/src/pm-rpc/privates/messageHandler.js#L3-L6) to `self` (only once).

This message handler is responsible for [resolving APIs](https://github.com/wix/pm-rpc/blob/master/src/pm-rpc/rpc.js#L37-L41) stored in `pm-rpc`.

When a user calls `request()` before `set()` is called at least once, we get an endless pending promise because the message handler wasn't set and there is nothing that can handle messages in `pm-rpc`

Also, this message handler is [removed](https://github.com/wix/pm-rpc/blob/master/src/pm-rpc/rpc.js#L79-L81) when all APIs are removed from `pm-rpc`.

That's why I verify that the message handler is set on every `request()` call.