### PR TITLE
Keep port on deepCloned messages that failed due to DataCloneError

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-rpc",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/wix/pm-rpc.git"

--- a/src/pm-rpc/privates/__tests__/messageManagerSpec.js
+++ b/src/pm-rpc/privates/__tests__/messageManagerSpec.js
@@ -33,6 +33,14 @@ describe('messageManager', () => {
       expect(target.postMessage).toHaveBeenCalledWith(message, [jasmine.any(MessagePort)])
     })
 
+    it('should call `target.postMessage` when message is an array', async () => {
+      const target = createTarget()
+      const message = [1]
+      await sendWithResolve(message, {target})
+
+      expect(target.postMessage).toHaveBeenCalledWith(message, [jasmine.any(MessagePort)])
+    })
+
     it('should not fail `target.postMessage` for messages with Proxy', async () => {
       const target = createTarget()
       const message = {a: '34de4cb70fd9', c: new Proxy({d: 0}, {get: _.constant(1)})}

--- a/src/pm-rpc/privates/__tests__/messageManagerSpec.js
+++ b/src/pm-rpc/privates/__tests__/messageManagerSpec.js
@@ -35,7 +35,7 @@ describe('messageManager', () => {
 
     it('should call `target.postMessage` when message is an array', async () => {
       const target = createTarget()
-      const message = [1]
+      const message = {a: 'e45cc3a216d8'}
       await sendWithResolve(message, {target})
 
       expect(target.postMessage).toHaveBeenCalledWith(message, [jasmine.any(MessagePort)])

--- a/src/pm-rpc/privates/messageManager.js
+++ b/src/pm-rpc/privates/messageManager.js
@@ -32,7 +32,19 @@ export const send = (message, {target, targetOrigin}, transfer = []) => new Prom
     */
 
     if (e && e.name === 'DataCloneError') {
+      /**
+       * This part is needed as lodash.cloneDeep on array doesnt clone additional object properties 
+       * For example -  
+       * const arr = [1,2,3]
+       * arr.port = 5 
+       * const b = cloneDeep(arr)
+       * arr.port === undefined.
+       */
+      const oldPort = message.__port
       const clonedMessage = cloneDeep(message)
+      if (oldPort) {
+        clonedMessage.__port = oldPort
+      }
       postMessage(target, clonedMessage, targetOrigin, [port2, ...transfer])
     } else {
       throw e

--- a/src/pm-rpc/privates/messageManager.js
+++ b/src/pm-rpc/privates/messageManager.js
@@ -32,6 +32,7 @@ export const send = (message, {target, targetOrigin}, transfer = []) => new Prom
     */
 
     if (e && e.name === 'DataCloneError') {
+      const clonedMessage = cloneDeep(message)
       /**
        * This part is needed as lodash.cloneDeep on array doesnt clone additional object properties 
        * For example -  
@@ -40,11 +41,7 @@ export const send = (message, {target, targetOrigin}, transfer = []) => new Prom
        * const b = cloneDeep(arr)
        * arr.port === undefined.
        */
-      const oldPort = message.__port
-      const clonedMessage = cloneDeep(message)
-      if (oldPort) {
-        clonedMessage.__port = oldPort
-      }
+      clonedMessage.__port = port2
       postMessage(target, clonedMessage, targetOrigin, [port2, ...transfer])
     } else {
       throw e


### PR DESCRIPTION
Keep port on deepCloned messages that failed due to DataCloneError
/**
 * This part is needed as lodash.cloneDeep on array doesnt clone additional object properties 
 * For example -  
 * const arr = [1,2,3]
 * arr.port = 5 
 * const b = cloneDeep(arr)
 * arr.port === undefined.
 */